### PR TITLE
Improvements according to release experience

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -172,9 +172,14 @@ func (c *Client) DoRequest(method string, url string, bodyType interface{}, resp
 	data, err := ioutil.ReadAll(resp.Body)
 	//Check on error
 	if err != nil || !(resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
-		log.Print("Response Error on request: ", reqURL)
-		log.Print("response Status:", resp.Status)
-		log.Print("response Headers:", resp.Header)
+
+		//ToDo: addapt on liima response after fixing (http.StatusBadRequest)
+		//Error response if node active=false in liima appserver configuration
+		if resp.StatusCode != http.StatusBadRequest {
+			log.Print("Response Error on request: ", reqURL)
+			log.Print("response Status:", resp.Status)
+			log.Print("response Headers:", resp.Header)
+		}
 		if err != nil {
 			return err
 		}

--- a/client/get_deployment.go
+++ b/client/get_deployment.go
@@ -81,7 +81,7 @@ const (
 // DeploymentState is the state of a Liima deployment
 type DeploymentState string
 
-//Enumeration of deplyoment state
+//Enumeration of deployment state
 const (
 	DeploymentStateSuccess        DeploymentState = "success"
 	DeploymentStateFailed         DeploymentState = "failed"

--- a/cmd/deployment/create.go
+++ b/cmd/deployment/create.go
@@ -12,7 +12,7 @@ var (
 	deploymentCreateLong = `	Create deployment with the use of specific properties.`
 
 	//Example command description
-	deploymentCreateExample = `	# Create a deplyoment with specific properties. 
+	deploymentCreateExample = `	# Create a deployment with specific properties. 
 	liimactl.exe deployment create --appServer=test_application --appName=ch_mobi_app1 --version="1.0.0" --appName=ch_mobi_app2 --version="1.0.1" --environment=I
 	liimactl.exe deployment create --appServer=aps_bau --appName=ch_mobi_aps_bau --version="1.0.32" --environment=W --date="2018-02-01 16:00"
 	liimactl.exe deployment create --appServer=generic_test --appName=ch_mobi_generic_test --version="1.0.1" --environment=U --wait`
@@ -39,12 +39,12 @@ func newCreateCommand(cli *client.Cli) *cobra.Command {
 	cmd.Flags().StringVarP(&commandOptionsCreate.Environment, "environment", "e", "", "Environment")
 	cmd.Flags().StringVarP(&commandOptionsCreate.Release, "release", "r", "", "Release")
 	cmd.Flags().StringVarP(&commandOptionsCreate.DeploymentDate, "date", "d", "", "Deployment Date 'YYYY.MM.DD hh:mm' ")
-	cmd.Flags().BoolVarP(&commandOptionsCreate.ExecuteShakedownTest, "executeShakeDownTest", "s", false, "Run Shakedowntest after the deplyoment")
+	cmd.Flags().BoolVarP(&commandOptionsCreate.ExecuteShakedownTest, "executeShakeDownTest", "s", false, "Run Shakedowntest after the deployment")
 	cmd.Flags().StringSliceVarP(&commandOptionsCreate.Key, "key", "k", []string{}, "Deploymentparameter Key")
 	cmd.Flags().StringSliceVarP(&commandOptionsCreate.Value, "value", "x", []string{}, "Deploymentparameter Value")
-	cmd.Flags().BoolVarP(&commandOptionsCreate.Wait, "wait", "w", false, "Wait maxWaitTime until the deplyoment success or failed")
-	cmd.Flags().IntVarP(&commandOptionsCreate.MaxWaitTime, "maxWaitTime", "t", 600, "Max Wait time [seconds] until the deplyoment success or failed")
-	cmd.Flags().StringVarP(&commandOptionsCreate.FromEnvironment, "fromEnvironment", "f", "", "Deploy last deplyoment from given environment")
+	cmd.Flags().BoolVarP(&commandOptionsCreate.Wait, "wait", "w", false, "Wait maxWaitTime until the deployment success or failed")
+	cmd.Flags().IntVarP(&commandOptionsCreate.MaxWaitTime, "maxWaitTime", "t", 600, "Max Wait time [seconds] until the deployment success or failed")
+	cmd.Flags().StringVarP(&commandOptionsCreate.FromEnvironment, "fromEnvironment", "f", "", "Deploy last deployment from given environment")
 
 	return cmd
 }

--- a/cmd/deployment/get.go
+++ b/cmd/deployment/get.go
@@ -14,7 +14,7 @@ var (
 	deploymentGetLong = `	Get deployment with the use of specific filters.`
 
 	//Example command description
-	deploymentGetExample = `	# Get a deplyoment with specific filters. 
+	deploymentGetExample = `	# Get a deployment with specific filters. 
 	liimactl.exe deployment get --appServer=test_application --environment=I
 	# Filters can also be passed as JSON
 	liimactl.exe deployment get --filter='[{"name":"Environment","comp":"eq","val":"Y"},{"name":"Application server","comp":"eq","val":"liima"}]'
@@ -41,7 +41,7 @@ func newGetCommand(cli *client.Cli) *cobra.Command {
 	deploymentState = &[]string{}
 	cmd.Flags().StringSliceVarP(&commandOptionsGet.AppName, "appName", "n", []string{}, "Application Name")
 	cmd.Flags().StringSliceVarP(&commandOptionsGet.AppServer, "appServer", "a", []string{}, "Application Server Name")
-	cmd.Flags().StringSliceVarP(deploymentState, "deploymentState", "d", []string{}, "Deplyoment State")
+	cmd.Flags().StringSliceVarP(deploymentState, "deploymentState", "d", []string{}, "deployment State")
 	cmd.Flags().StringSliceVarP(&commandOptionsGet.Environment, "environment", "e", []string{}, "Environment Filter")
 	cmd.Flags().BoolVarP(&commandOptionsGet.OnlyLatest, "onlyLatest", "l", false, "Only Latest Filter")
 	cmd.Flags().IntVarP(&commandOptionsGet.TrackingID, "trackingId", "t", -1, "Tracking ID")
@@ -51,7 +51,7 @@ func newGetCommand(cli *client.Cli) *cobra.Command {
 	return cmd
 }
 
-//Get the deployments properties given by the arguments (see type Deplyoments) and print it on the console
+//Get the deployments properties given by the arguments (see type Deployments) and print it on the console
 func runGet(cmd *cobra.Command, cli *client.Cli, args []string) {
 	// convert to client types
 	for _, state := range *deploymentState {


### PR DESCRIPTION
- Check error response if node active=false in liima appserver configuration
- Print the "node active=false" deployments with state "rejected"
- Fix typing error
- Fix Promote deployment: only last "success" deployment
- Print the promoted deployments grouped by the deployment state